### PR TITLE
refactor enhancement dropdown and don't show enhancement if they select 'none'

### DIFF
--- a/src/HandSelection.js
+++ b/src/HandSelection.js
@@ -37,26 +37,6 @@ function HandSelection({
   const levelNineCards = character.cards.filter((card) => {
     return card.level === 9
   })
-  const enhancementOptions = [
-    '+1',
-    'Leap',
-    'Wind',
-    'Ice',
-    'Fire',
-    'Leaf',
-    'Sun',
-    'Moon',
-    'Wild Element',
-    'Bless',
-    'Curse',
-    'Disarm',
-    'Immobilize',
-    'Wound',
-    'Muddle',
-    'Poison',
-    'Strengthen',
-    'Area',
-  ]
 
   function cardIsInHand(cardToCheck) {
     if (hand.some((card) => card.title === cardToCheck.title)) {
@@ -110,7 +90,6 @@ function HandSelection({
             handleCardClick={handleCardClick}
             cardSet={firstRow}
             character={character}
-            enhancementOptions={enhancementOptions}
             handleEnhancementChange={handleEnhancementChange}
           />
           <CardTableRowLevelOne
@@ -118,7 +97,6 @@ function HandSelection({
             handleCardClick={handleCardClick}
             cardSet={secondRow}
             character={character}
-            enhancementOptions={enhancementOptions}
             handleEnhancementChange={handleEnhancementChange}
           />
           <CardTableRowLevelOne
@@ -126,7 +104,6 @@ function HandSelection({
             handleCardClick={handleCardClick}
             cardSet={thirdRow}
             character={character}
-            enhancementOptions={enhancementOptions}
             handleEnhancementChange={handleEnhancementChange}
           />
           {level >= 2 && (
@@ -134,7 +111,6 @@ function HandSelection({
               cardIsInHand={cardIsInHand}
               handleCardClick={handleCardClick}
               character={character}
-              enhancementOptions={enhancementOptions}
               handleEnhancementChange={handleEnhancementChange}
               firstCardSet={levelTwoCards}
               firstLevel={2}
@@ -148,7 +124,6 @@ function HandSelection({
               cardIsInHand={cardIsInHand}
               handleCardClick={handleCardClick}
               character={character}
-              enhancementOptions={enhancementOptions}
               handleEnhancementChange={handleEnhancementChange}
               firstCardSet={levelFourCards}
               firstLevel={4}
@@ -162,7 +137,6 @@ function HandSelection({
               cardIsInHand={cardIsInHand}
               handleCardClick={handleCardClick}
               character={character}
-              enhancementOptions={enhancementOptions}
               handleEnhancementChange={handleEnhancementChange}
               firstCardSet={levelSixCards}
               firstLevel={6}
@@ -176,7 +150,6 @@ function HandSelection({
               cardIsInHand={cardIsInHand}
               handleCardClick={handleCardClick}
               character={character}
-              enhancementOptions={enhancementOptions}
               handleEnhancementChange={handleEnhancementChange}
               firstCardSet={levelEightCards}
               firstLevel={8}
@@ -217,7 +190,6 @@ function CardTableRowLevelOne({
   handleCardClick,
   cardSet,
   character,
-  enhancementOptions,
   handleEnhancementChange,
 }) {
   return (
@@ -255,29 +227,12 @@ function CardTableRowLevelOne({
             <td key={`${card.title}-Enhancements`} className="enhancement">
               {card.enhancements.map((enhancement, index) => {
                 return (
-                  <div
+                  <EnhancementDropdown
+                    card={card}
+                    enhancement={enhancement}
+                    handleEnhancementChange={handleEnhancementChange}
                     key={`${card.title}-${index}`}
-                    className="enhancement-row"
-                  >
-                    <label className="enhancement">Enhancement:</label>
-                    <select
-                      onChange={(e) =>
-                        handleEnhancementChange(card.title, enhancement.id, e)
-                      }
-                    >
-                      <option value="none">None</option>
-                      {enhancementOptions.map((enhancementOption) => {
-                        return (
-                          <option
-                            key={enhancementOption}
-                            value={enhancementOption}
-                          >
-                            {enhancementOption}
-                          </option>
-                        )
-                      })}
-                    </select>
-                  </div>
+                  />
                 )
               })}
             </td>
@@ -292,7 +247,6 @@ function CardTableRowTwoLevels({
   cardIsInHand,
   handleCardClick,
   character,
-  enhancementOptions,
   handleEnhancementChange,
   firstCardSet,
   firstLevel,
@@ -365,29 +319,12 @@ function CardTableRowTwoLevels({
             <td key={`${card.title}-Enhancements`} className="enhancement">
               {card.enhancements.map((enhancement, index) => {
                 return (
-                  <div
+                  <EnhancementDropdown
+                    card={card}
+                    enhancement={enhancement}
+                    handleEnhancementChange={handleEnhancementChange}
                     key={`${card.title}-${index}`}
-                    className="enhancement-row"
-                  >
-                    <label className="enhancement">Enhancement:</label>
-                    <select
-                      onChange={(e) =>
-                        handleEnhancementChange(card.title, enhancement.id, e)
-                      }
-                    >
-                      <option value="none">None</option>
-                      {enhancementOptions.map((enhancementOption) => {
-                        return (
-                          <option
-                            key={enhancementOption}
-                            value={enhancementOption}
-                          >
-                            {enhancementOption}
-                          </option>
-                        )
-                      })}
-                    </select>
-                  </div>
+                  />
                 )
               })}
             </td>
@@ -401,33 +338,12 @@ function CardTableRowTwoLevels({
                 <td key={`${card.title}-Enhancements`} className="enhancement">
                   {card.enhancements.map((enhancement, index) => {
                     return (
-                      <div
+                      <EnhancementDropdown
+                        card={card}
+                        enhancement={enhancement}
+                        handleEnhancementChange={handleEnhancementChange}
                         key={`${card.title}-${index}`}
-                        className="enhancement-row"
-                      >
-                        <label className="enhancement">Enhancement:</label>
-                        <select
-                          onChange={(e) =>
-                            handleEnhancementChange(
-                              card.title,
-                              enhancement.id,
-                              e
-                            )
-                          }
-                        >
-                          <option value="none">None</option>
-                          {enhancementOptions.map((enhancementOption) => {
-                            return (
-                              <option
-                                key={enhancementOption}
-                                value={enhancementOption}
-                              >
-                                {enhancementOption}
-                              </option>
-                            )
-                          })}
-                        </select>
-                      </div>
+                      />
                     )
                   })}
                 </td>
@@ -437,6 +353,47 @@ function CardTableRowTwoLevels({
         )}
       </tr>
     </>
+  )
+}
+
+function EnhancementDropdown({ card, enhancement, handleEnhancementChange }) {
+  const enhancementOptions = [
+    '+1',
+    'Leap',
+    'Wind',
+    'Ice',
+    'Fire',
+    'Leaf',
+    'Sun',
+    'Moon',
+    'Wild Element',
+    'Bless',
+    'Curse',
+    'Disarm',
+    'Immobilize',
+    'Wound',
+    'Muddle',
+    'Poison',
+    'Strengthen',
+    'Area',
+  ]
+
+  return (
+    <div className="enhancement-row">
+      <label className="enhancement">Enhancement:</label>
+      <select
+        onChange={(e) => handleEnhancementChange(card.title, enhancement.id, e)}
+      >
+        <option value="">None</option>
+        {enhancementOptions.map((enhancementOption) => {
+          return (
+            <option key={enhancementOption} value={enhancementOption}>
+              {enhancementOption}
+            </option>
+          )
+        })}
+      </select>
+    </div>
   )
 }
 


### PR DESCRIPTION
If someone selected an enhancement and then changed their mind, the enhancement value was changing to 'none' for that slot and the component was showing a broken image.

This refactors the dropdown to make it easier to manage, and returns '' for the enhancement selected instead of 'none' when this happens.